### PR TITLE
fix: Handle missing git tags in conanfile.py

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -18,16 +18,14 @@ class XlntConan(ConanFile):
 
     def set_version(self):
         if not hasattr(self, 'version') or not self.version:
-            git = Git(self, folder=self.recipe_folder)
-            try:
-                # Try to get version from git tag
-                tag = git.run("describe --tags --exact-match HEAD").strip()
-                if tag.startswith('v'):
-                    self.version = tag[1:]  # Remove 'v' prefix
+            conan_version = os.environ.get("CONAN_VERSION")
+            if conan_version:
+                if conan_version.startswith('v'):
+                    self.version = conan_version[1:]  # Remove 'v' prefix
                 else:
-                    self.version = tag
-            except RuntimeError:
-                # Fallback to default version if no tag found
+                    self.version = conan_version
+            else:
+                # Fallback to default version if CONAN_VERSION not found
                 self.version = "1.5.0"
 
     def layout(self):


### PR DESCRIPTION
The `set_version` method in `conanfile.py` previously attempted to derive the package version from git tags using `git describe --tags --exact-match HEAD`. This command fails if the current commit does not have an exact tag, leading to a `ConanException`.

This commit modifies the `set_version` method to remove the reliance on `git describe`. Instead, if the `CONAN_VERSION` environment variable is not set, the package version will now default to "1.5.0". This ensures that the Conan recipe can be exported successfully even when the repository is not at a tagged commit.