### PR TITLE
fix: Use cmake.install() in package() method

### DIFF
--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,7 @@
+fix: Use cmake.install() in package() method
+
+Replaced manual file copying in the `package()` method of `conanfile.py`
+with `cmake.install()`. This leverages CMake's built-in install rules
+for the xlnt library, ensuring that the library files are correctly
+placed in the Conan package, which should resolve the 'Library not found'
+error during the test_package build.

--- a/conanfile.py
+++ b/conanfile.py
@@ -65,12 +65,7 @@ class XlntConan(ConanFile):
         cmake.build()
 
     def package(self):
-        copy(self, "*.hpp", dst=os.path.join(self.package_folder, "include"), src=os.path.join(self.source_folder, "include"))
-        copy(self, "*.lib", dst=os.path.join(self.package_folder, "lib"), src=self.build_folder, keep_path=False)
-        copy(self, "*.dll", dst=os.path.join(self.package_folder, "bin"), src=self.build_folder, keep_path=False)
-        copy(self, "*.so", dst=os.path.join(self.package_folder, "lib"), src=self.build_folder, keep_path=False)
-        copy(self, "*.dylib", dst=os.path.join(self.package_folder, "lib"), src=self.build_folder, keep_path=False)
-        copy(self, "*.a", dst=os.path.join(self.package_folder, "lib"), src=self.build_folder, keep_path=False)
+        cmake.install()
 
     def package_info(self):
         self.cpp_info.libs = ["xlnt" if self.settings.build_type == "Release" else "xlntd"]


### PR DESCRIPTION
Replaced manual file copying in the `package()` method of `conanfile.py` with `cmake.install()`. This leverages CMake's built-in install rules for the xlnt library, ensuring that the library files are correctly placed in the Conan package, which should resolve the 'Library not found' error during the test_package build.